### PR TITLE
Enable Assertive Display [1/2]

### DIFF
--- a/ham/ham-vendor-blobs.mk
+++ b/ham/ham-vendor-blobs.mk
@@ -181,6 +181,7 @@ PRODUCT_COPY_FILES += \
     vendor/zuk/ham/proprietary/vendor/lib/libxml.so:system/vendor/lib/libxml.so \
     vendor/zuk/ham/proprietary/bin/sensors.qcom:system/bin/sensors.qcom \
     vendor/zuk/ham/proprietary/etc/sensor_def_qcomdev.conf:system/etc/sensor_def_qcomdev.conf \
+    vendor/zuk/ham/proprietary/etc/ad_calib.cfg:system/etc/ad_calib.cfg \
     vendor/zuk/ham/proprietary/vendor/lib/hw/activity_recognition.msm8974.so:system/vendor/lib/hw/activity_recognition.msm8974.so \
     vendor/zuk/ham/proprietary/vendor/lib/hw/sensors.msm8974.so:system/vendor/lib/hw/sensors.msm8974.so \
     vendor/zuk/ham/proprietary/vendor/lib/libsensor1.so:system/vendor/lib/libsensor1.so \

--- a/ham/proprietary/etc/ad_calib.cfg
+++ b/ham/proprietary/etc/ad_calib.cfg
@@ -1,0 +1,111 @@
+#                   Assertive Display Calibration Output File Format
+# Calibration config file consists of one or more sections. Each section is set
+# of parameter values stored on one line each. Number of parameters (hence number
+# of lines in each section is fixed. Order in which parameters are specified in
+# given section is fixed as well.
+# Comments are supported in configuration file to improve readability of
+# calibration configuration parameters. Any line begining with '#' is considered
+# as comment and will not be processed further.
+# Blank lines are allowed and are ignored. They can be used to improve
+# readability of assertive display calibration output file.
+# Sections: Any line begining with '=' indicates start of new section in
+# calibration output file. Sections, parameters which are part of section and
+# order in which they will appear in calibration output file is kept outside
+# scope of this documentation in order to have flexibility in development of
+# assertive display calibration system. This information can be shared between
+# APICAL and Qualcomm as part of assertive display bring ups on given platforms.
+# There should not be any spaces betweetn '=' and section name.
+# Version 1.0 of calibration output format supports following sections:
+# version - Contains assertive display calibration output file format version
+# init -  Contains assertive display parameters which are independent of
+#	  assertive display mode
+# config - Contains assertive display parameters which are dependent on specific
+#	   assertive display mode
+# Each parameter for assertive display calibration is stored on new line. If
+# parameter consists of more than one values (set of values), each value is
+# separated by single space (' ') character. In version 1.0  of assertive
+# display calibration output file format, all numerical values are in decimal
+# unsigned integer format, limited by 32 bits. Range for values or valid value
+# for given parameter is outside scope of this documentation. This information
+# can be shared between APICAL and Qualcomm as part of assertive display bring
+# ups on given platforms.
+# Version 1.1 adds two more init parameters (21 in total) to the config file to support the
+# newly added power saving  feature, Parameters added are alpha and BL_ATT lut
+# Version 1.2 adds two more init parameters (23 in total) to the config file to support the
+# driver change, Parameters added are ALS_offset and ALS_threshold
+# Version 1.3 changes the parameters BL linearity LUT and BL inverse LUT
+# from 8 bit to 12 bits. This is done to support the precision increase in the AD Driver
+=version
+1.3
+# APICAL mode indepent initialization Params
+=init
+# A
+0 211 414 609 796 975 1148 1315 1475 1630 1779 1922 2061 2195 2325 2451 2572 2690 2804 2915 3022 3126 3227 3325 3420 3513 3603 3691 3776 3859 3940 4019 4095
+# B
+255 278 302 326 350 374 398 422 446 470 494 517 541 565 589 613 637 661 684 708 732 755 779 803 826 850 874 897 921 945 968 992 1016
+# C
+7 134
+# D
+0
+# E
+1023
+# F
+65
+# G
+240
+# H
+0
+# I
+60
+# J
+128
+# dither_control
+5
+# L
+3
+# M
+0
+# frame_width
+1080
+# frame_height
+1920
+# P
+0
+# Q
+0
+# BL_linearity_LUT
+0 16 32 48 64 80 96 112 128 145 161 177 193 209 225 241 257 273 289 305 321 337 353 369 385 401 418 434 450 466 482 498 514 530 546 562 578 594 610 626 642 658 674 691 707 723 739 755 771 787 803 819 835 851 867 883 899 915 931 947 964 980 996 1012 1028 1044 1060 1076 1092 1108 1124 1140 1156 1172 1188 1204 1220 1237 1253 1269 1285 1301 1317 1333 1349 1365 1381 1397 1413 1429 1445 1461 1477 1493 1510 1526 1542 1558 1574 1590 1606 1622 1638 1654 1670 1686 1702 1718 1734 1750 1766 1783 1799 1815 1831 1847 1863 1879 1895 1911 1927 1943 1959 1975 1991 2007 2023 2039 2056 2072 2088 2104 2120 2136 2152 2168 2184 2200 2216 2232 2248 2264 2280 2296 2312 2329 2345 2361 2377 2393 2409 2425 2441 2457 2473 2489 2505 2521 2537 2553 2569 2585 2602 2618 2634 2650 2666 2682 2698 2714 2730 2746 2762 2778 2794 2810 2826 2842 2858 2875 2891 2907 2923 2939 2955 2971 2987 3003 3019 3035 3051 3067 3083 3099 3115 3131 3148 3164 3180 3196 3212 3228 3244 3260 3276 3292 3308 3324 3340 3356 3372 3388 3404 3421 3437 3453 3469 3485 3501 3517 3533 3549 3565 3581 3597 3613 3629 3645 3661 3677 3694 3710 3726 3742 3758 3774 3790 3806 3822 3838 3854 3870 3886 3902 3918 3934 3950 3967 3983 3999 4015 4031 4047 4063 4079 4095
+# BL_linearity_inverse_LUT
+0 16 32 48 64 80 96 112 128 145 161 177 193 209 225 241 257 273 289 305 321 337 353 369 385 401 418 434 450 466 482 498 514 530 546 562 578 594 610 626 642 658 674 691 707 723 739 755 771 787 803 819 835 851 867 883 899 915 931 947 964 980 996 1012 1028 1044 1060 1076 1092 1108 1124 1140 1156 1172 1188 1204 1220 1237 1253 1269 1285 1301 1317 1333 1349 1365 1381 1397 1413 1429 1445 1461 1477 1493 1510 1526 1542 1558 1574 1590 1606 1622 1638 1654 1670 1686 1702 1718 1734 1750 1766 1783 1799 1815 1831 1847 1863 1879 1895 1911 1927 1943 1959 1975 1991 2007 2023 2039 2056 2072 2088 2104 2120 2136 2152 2168 2184 2200 2216 2232 2248 2264 2280 2296 2312 2329 2345 2361 2377 2393 2409 2425 2441 2457 2473 2489 2505 2521 2537 2553 2569 2585 2602 2618 2634 2650 2666 2682 2698 2714 2730 2746 2762 2778 2794 2810 2826 2842 2858 2875 2891 2907 2923 2939 2955 2971 2987 3003 3019 3035 3051 3067 3083 3099 3115 3131 3148 3164 3180 3196 3212 3228 3244 3260 3276 3292 3308 3324 3340 3356 3372 3388 3404 3421 3437 3453 3469 3485 3501 3517 3533 3549 3565 3581 3597 3613 3629 3645 3661 3677 3694 3710 3726 3742 3758 3774 3790 3806 3822 3838 3854 3870 3886 3902 3918 3934 3950 3967 3983 3999 4015 4031 4047 4063 4079 4095
+# power_saving_coeff
+1
+# BL_att_LUT
+0 128 256 384 512 539 567 594 622 649 676 704 768 832 896 960 1024 1088 1152 1216 1280 1612 1945 2278 2611 2943 3327 3455 3583 3711 3839 3967 4095
+# al_offset
+10000
+# al_tolarance
+0.2
+#APICAL mode specific configuration
+=config
+# mode
+1
+# R
+0 2048 4096 6144 8192 10240 12288 14336 16384 18432 20480 22528 24576 26624 28672 30720 32768 34815 36863 38911 40959 43007 45055 47103 49151 51199 53247 55295 57343 59391 61439 63487 65535
+# back_min
+0
+# back_max
+4095
+# back_scale
+4095
+# ambient_light_min
+0
+# S
+1738 6
+# calibration_abcd
+12 95 0 0
+# T
+128
+# U
+5
+# V
+60


### PR DESCRIPTION
Added ad_calib.cfg to enable Assertive Display on this device.
Info about Assertive Display: http://www.apical.co.uk/assertive/display/

---

This also needs the following pull request in the Gerrit to work:
https://review.cyanogenmod.org/152337
